### PR TITLE
fix: block global commands from dm

### DIFF
--- a/discord/command/dm.go
+++ b/discord/command/dm.go
@@ -1,0 +1,20 @@
+package command
+
+import (
+	"github.com/automuteus/utils/pkg/settings"
+	"github.com/bwmarrin/discordgo"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+)
+
+func DmResponse(sett *settings.GuildSettings) *discordgo.InteractionResponse {
+	return &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: sett.LocalizeMessage(&i18n.Message{
+				ID: "commands.dm",
+				Other: "Sorry, I cant't respond to DM. " +
+					"Please execute the command in text channel instead.",
+			}),
+		},
+	}
+}

--- a/discord/slash_commands.go
+++ b/discord/slash_commands.go
@@ -24,6 +24,16 @@ func (bot *Bot) handleInteractionCreate(s *discordgo.Session, i *discordgo.Inter
 
 	var response *discordgo.InteractionResponse
 
+	// block commands from dm
+	if gsr.GuildID == "" {
+		response = command.DmResponse(sett)
+		err := s.InteractionRespond(i.Interaction, response)
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
 	switch i.ApplicationCommandData().Name {
 	case "help":
 		response = command.HelpResponse(sett, i.ApplicationCommandData().Options)


### PR DESCRIPTION
This is a PR for **slash-command** branch.
The Global Commands are available in DMs, so it should be blocked to avoid unintended issue when the `i.GuildID` is empty.

> An individual app's global commands are also available in DMs if that app has a bot that shares a mutual guild with the user.
> <https://discord.com/developers/docs/interactions/application-commands#registering-a-command>

If you have the plan to handle this or your code is under developing about this, feel free to reject this PR 🚀 