### PR TITLE
fix: add role type which can be handled as args for slash-command

### DIFF
--- a/discord/setting/settings.go
+++ b/discord/setting/settings.go
@@ -2,6 +2,7 @@ package setting
 
 import (
 	"fmt"
+
 	"github.com/automuteus/utils/pkg/game"
 	"github.com/automuteus/utils/pkg/settings"
 	"github.com/bwmarrin/discordgo"
@@ -72,6 +73,8 @@ func ToString(option *discordgo.ApplicationCommandInteractionDataOption, s *disc
 		return fmt.Sprintf("%d", option.IntValue())
 	case discordgo.ApplicationCommandOptionUser:
 		return option.UserValue(s).Mention()
+	case discordgo.ApplicationCommandOptionRole:
+		return option.RoleValue(s, "").Mention()
 	case discordgo.ApplicationCommandOptionChannel:
 		return option.ChannelValue(s).Mention()
 	case discordgo.ApplicationCommandOptionSubCommand:


### PR DESCRIPTION
**This PR is for `slash-commands` branch**.

Add `ApplicationCommandOptionRole` type to be able to handle Role IDs as argments for slash commands, since the command `/settings operator-roles role:@hoge` makes the `Option` with this type.

Currently the command doesn't works well since any roles always determined as `""`.