### PR TITLE
fix: remove hourglass from followup message

### DIFF
--- a/discord/slash_commands.go
+++ b/discord/slash_commands.go
@@ -3,6 +3,11 @@ package discord
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
 	redis_common "github.com/automuteus/automuteus/common"
 	"github.com/automuteus/automuteus/discord/command"
 	"github.com/automuteus/automuteus/discord/setting"
@@ -12,10 +17,6 @@ import (
 	"github.com/automuteus/utils/pkg/settings"
 	"github.com/bwmarrin/discordgo"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
-	"log"
-	"regexp"
-	"strings"
-	"time"
 )
 
 var MatchIDRegex = regexp.MustCompile(`^[A-Z0-9]{8}:[0-9]+$`)
@@ -68,8 +69,12 @@ func (bot *Bot) handleInteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		case resp := <-respondChan:
 			if followUpMsg != nil {
 				if resp != nil && resp.Data != nil {
+					content := resp.Data.Content
+					if content == "" {
+						content = "\u200b"
+					}
 					followUpMsg, err = s.FollowupMessageEdit(s.State.User.ID, i.Interaction, followUpMsg.ID, &discordgo.WebhookEdit{
-						Content:    resp.Data.Content,
+						Content:    content,
 						Components: resp.Data.Components,
 						Embeds:     resp.Data.Embeds,
 					})


### PR DESCRIPTION
In the current implementation, the big hourglass ⌛ remains forever if;

- the command takes over 2 seconds,
- and the updated followup message is `embed` type instead of `content` type

since the empty content `""` doesn't replace existing message content. This is a bit annoying.

![image](https://user-images.githubusercontent.com/2920259/162213696-cc41531b-8707-4ee4-b637-04662df9b499.png)

This PR replace this hourglass with `\u200b` if the updated followup message contains empty content `""`.

![image](https://user-images.githubusercontent.com/2920259/162214322-fa8a6ce2-8a4a-4b95-bc64-70dc3268164a.png)

