### PR TITLE
fix: add strings for translation from utils module

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ To extract strings for translation to `locales/en.toml`:
 
 ```
 goi18n extract -outdir locales
+curl -s https://raw.githubusercontent.com/automuteus/utils/main/locales/active.en.toml >> locales/active.en.toml
+sed -i 's/\\n/\\\\n/g' locales/active.en.toml
 ```
 
 # Self-Hosting

--- a/locales/active.en.toml
+++ b/locales/active.en.toml
@@ -195,3 +195,5 @@
 "state.phase.LOBBY" = "LOBBY"
 "state.phase.MENU" = "MENU"
 "state.phase.TASKS" = "TASKS"
+"locale.language.name" = "English"
+"responses.matchStatsEmbed.Title" = "Game `{{.MatchID}}`"


### PR DESCRIPTION
Closes automuteus/utils#5

Thanks for adding locales on utils repository.
If this make some conflicts with your working tree or if you know more appropriate way, it's ok to revoke this.