### PR TITLE
Fix Clear User Cache user option

### DIFF
--- a/discord/command/debug.go
+++ b/discord/command/debug.go
@@ -76,8 +76,8 @@ func GetDebugParams(s *discordgo.Session, userID string, options []*discordgo.Ap
 			userID = options[0].Options[0].Options[0].UserValue(s).ID
 		}
 	case setting.Clear:
-		if len(options[0].Options[0].Options) > 0 {
-			userID = options[0].Options[0].Options[0].UserValue(s).ID
+		if len(options[0].Options) > 0 {
+			userID = options[0].Options[0].UserValue(s).ID
 		}
 	}
 	return action, opType, userID


### PR DESCRIPTION
/debug clear command does not take user option properly.
This happens because /debug command's "**view**" and "**clear**" takes different length of option.

As you can see from the screenshot below, **view** operation has three options
![image](https://user-images.githubusercontent.com/10671253/201260708-5f9dba17-ddcf-4f61-83b5-3b13d42346c4.png)
Therefore.
option[0].Name = view
option[0].Option[0].Name = user or game-state
option[0].Option[0].Option[0].UserValue(s) = user:{input given by user}

However, clear command does not have third option so
![image](https://user-images.githubusercontent.com/10671253/201260729-c166679d-415d-47ef-973b-2708465cf8c5.png)
option[0].Name = clear
option[0].Option[0].Name = user (because input option name is user)
option[0].Option[0].Option is always empty.
Therefore, userId will remain as default rather than user option given by user. (Person who raised the interaction command)

Accordingly, I propose to take second Option like in this PR.

Or change "**/debug clear user:**" command to "**/debug clear user user:**" 
From slash_commands.go code, I think that is what you are intended to do but I am not sure you would like to change existing command so raised PR to let existing command working.
I will leave the decision to you for how you would like to handle it.