### PR TITLE
fix: add missing commands in help command

### DIFF
--- a/discord/command/help.go
+++ b/discord/command/help.go
@@ -65,6 +65,14 @@ var Help = discordgo.ApplicationCommand{
 					Name:  Premium.Name,
 					Value: Premium.Name,
 				},
+				{
+					Name:  Debug.Name,
+					Value: Debug.Name,
+				},
+				{
+					Name:  Download.Name,
+					Value: Download.Name,
+				},
 			},
 			Required: false,
 		},


### PR DESCRIPTION
This is almost meaningless, but just in case :P