### PR TITLE
fix: disable cgo for swagger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN go install github.com/swaggo/swag/cmd/swag@v1.8.12
 # Import the code from the context.
 COPY ./ ./
 # Generate API documentation
-RUN swag init --parseDependency true
+RUN CGO_ENABLED=0 swag init --parseDependency true
 
 # Build the executable to `/app`. Mark the build as statically linked.
 # hadolint ignore=SC2155


### PR DESCRIPTION
Disable cgo for swagger to avoid some errors on build.

> [builder 8/9] RUN swag init --parseDependency true
> 0.195 2023/07/20 05:42:57 Generate swagger docs....
> 0.195 2023/07/20 05:42:57 Generate general API Info, search dir:./
> ...
> 3.217 cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in $PATH
> 3.392 cgo failed: [go tool cgo -objdir /tmp/net_C897375797 -- -I /tmp/net_C897375797 cgo_linux.go cgo_resnew.go cgo_socknew.go cgo_unix.go]: exit status 1

As discussed in Discord these errors can be ignored, but just disabling cgo can solve this instead of installing gcc, so I create this PR.
Tested locally and seems no side effect for generated docs.